### PR TITLE
Issues/29

### DIFF
--- a/src/main/ml-modules/ext/gds.sjs
+++ b/src/main/ml-modules/ext/gds.sjs
@@ -10,7 +10,7 @@ function getServiceModel(serviceName) {
   let model = fn.head(
     cts.search(cts.andQuery([
       cts.collectionQuery(collection),
-      cts.jsonPropertyValueQuery("name", serviceName)
+      cts.jsonPropertyValueQuery("name", serviceName, ["exact"])
     ]))
   );
 

--- a/src/main/ml-modules/ext/gds.sjs
+++ b/src/main/ml-modules/ext/gds.sjs
@@ -1,0 +1,26 @@
+'use strict';
+
+function getServiceModel(serviceName) {
+  xdmp.trace("KOOP-DEBUG", "Starting getServiceModel");
+  // TODO: These should be cached
+
+  const collection = "http://marklogic.com/feature-services";
+
+  xdmp.trace("KOOP-DEBUG", "Searching for Service Model: " + serviceName);
+  let model = fn.head(
+    cts.search(cts.andQuery([
+      cts.collectionQuery(collection),
+      cts.jsonPropertyValueQuery("name", serviceName)
+    ]))
+  );
+
+  if (model) {
+    xdmp.trace("KOOP-DEBUG", "Found service: " + serviceName);
+    return model.toObject();
+  } else {
+    xdmp.trace("KOOP-DEBUG", "No service info found for: " + serviceName);
+    throw "No service info found for: " + serviceName;
+  }
+}
+
+exports.getServiceModel = getServiceModel;

--- a/src/main/ml-modules/services/KoopFeatureLayer.sjs
+++ b/src/main/ml-modules/services/KoopFeatureLayer.sjs
@@ -10,16 +10,24 @@ const koopConfigUri = '/koop/config.json';
 // Returns all feature layers of a feature service
 function get(context, params) {
   try {
-    var response = {};
-    
-    var serviceName = params.service;
-    var model = gds.getServiceModel(serviceName);
+    xdmp.trace('GDS-DEBUG', 'Start GET KoopFeatureLayer');
 
-    if (model === null) {
-      fn.error(null, 'Unable to find service ' + serviceName + '.');
+    var response = {};
+    var serviceName = params.service;
+    if (!serviceName) {
+      const errorMsg = 'Request parameter \"service\" is missing or has no value';
+      xdmp.trace('GDS-DEBUG', errorMsg);
+      throw { code: 400, msg: errorMsg };
     }
 
-    model = model.toObject();
+    var model = null;
+    try { model = gds.getServiceModel(serviceName); }
+    catch (err) {
+      const errorMsg = 'Unable to find service with name \"' + serviceName + '\"';
+      xdmp.trace('GDS-DEBUG', 'Exception thrown by gds.getServiceModel(): ' + JSON.stringify(err));
+      throw { code: 404, msg: errorMsg };
+    }
+
     var layers = model.layers;
     if (params.readOnly) {
       var filterReadOnly = fn.lowerCase(params.readOnly) === 'true';
@@ -36,11 +44,20 @@ function get(context, params) {
       layers: layers
     }
 
+    xdmp.trace('GDS-DEBUG', 'Response: ' + JSON.stringify(response));
     return response;
   }
   catch (err) {
-    console.trace(err);
-    returnErrToClient(500, 'Error handling request', err.toString());
+    xdmp.trace('GDS-DEBUG', 'Responding with error due to exception: ' + JSON.stringify(err));
+    if (err.code && err.msg) {
+      returnErrToClient(err.code, 'Error handling request', err.msg);
+    }
+    else {
+      returnErrToClient(500, 'Error handling request', JSON.stringify(err));
+    }
+  }
+  finally {
+    xdmp.trace('GDS-DEBUG', 'End GET KoopFeatureLayer');
   }
 }
 

--- a/src/main/ml-modules/services/KoopFeatureLayer.sjs
+++ b/src/main/ml-modules/services/KoopFeatureLayer.sjs
@@ -1,12 +1,11 @@
 'use strict';
 
+const gds = require('/ext/gds.sjs');
 const search = require('/MarkLogic/appservices/search/search.xqy');
 const sut = require('/MarkLogic/rest-api/lib/search-util.xqy');
 const ast = require('/MarkLogic/appservices/search/ast.xqy');
 
-
 const koopConfigUri = '/koop/config.json';
-const collFeatureServices = 'http://marklogic.com/feature-services';
 
 // Returns all feature layers of a feature service
 function get(context, params) {
@@ -14,7 +13,7 @@ function get(context, params) {
     var response = {};
     
     var serviceName = params.service;
-    var model = getServiceModel(serviceName);
+    var model = gds.getServiceModel(serviceName);
 
     if (model === null) {
       fn.error(null, 'Unable to find service ' + serviceName + '.');
@@ -49,7 +48,7 @@ function get(context, params) {
 function put(context, params, input) {
   try {
     var serviceName = params.service;
-    var model = getServiceModel(serviceName);
+    var model = gds.getServiceModel(serviceName);
     var schema = params.schema || serviceName;
 
     if (model === null) {
@@ -115,14 +114,6 @@ function put(context, params, input) {
     console.trace(err);
     returnErrToClient(500, 'Error handling request', err.toString());
   }
-}
-
-function getServiceModel(serviceName) {
-  return fn.head(cts.search(
-    cts.andQuery([
-      cts.collectionQuery(collFeatureServices),
-      cts.jsonPropertyValueQuery("name", serviceName)
-    ])));
 }
 
 function createNewLayerObj(id, name, desc, geometryType, schema, view) {

--- a/src/main/ml-modules/services/geoQueryService.sjs
+++ b/src/main/ml-modules/services/geoQueryService.sjs
@@ -6,6 +6,7 @@
 
 const op = require('/MarkLogic/optic');
 const geojson = require('/MarkLogic/geospatial/geojson.xqy');
+const gds = require('/ext/gds.sjs');
 const sql2optic = require('/ext/sql/sql2optic.sjs');
 const geostats = require('/ext/geo/geostats.js');
 const geoextractor = require('/ext/geo/extractor.sjs');
@@ -68,34 +69,11 @@ function getData(req) {
   returnErrToClient(501, 'Request parameters not supported', xdmp.quote(req));
 }
 
-function getServiceModel(serviceName) {
-  xdmp.trace("KOOP-DEBUG", "Starting getServiceModel");
-  // TODO: These should be cached
-
-  const collection = "http://marklogic.com/feature-services";
-
-  xdmp.trace("KOOP-DEBUG", "Searching for Service Model: " + serviceName);
-  let model = fn.head(
-    cts.search(cts.andQuery([
-      cts.collectionQuery(collection),
-      cts.jsonPropertyValueQuery("name", serviceName)
-    ]))
-  );
-
-  if (model) {
-    xdmp.trace("KOOP-DEBUG", "Found service: " + serviceName);
-    return model.toObject();
-  } else {
-    xdmp.trace("KOOP-DEBUG", "No service info found for: " + serviceName);
-    throw "No service info found for: " + serviceName;
-  }
-}
-
 function getLayerModel(serviceName, layerId) {
   xdmp.trace("KOOP-DEBUG", "Starting getLayerModel");
   // TODO: These should be cached
 
-  const serviceModel = getServiceModel(serviceName);
+  const serviceModel = gds.getServiceModel(serviceName);
 
   let layer = null;
   if (serviceModel) {
@@ -153,7 +131,7 @@ function generateServiceDescriptor(serviceName) {
 
   // TODO: we should cache this instead of generating it every time
 
-  const model = getServiceModel(serviceName);
+  const model = gds.getServiceModel(serviceName);
 
   const desc = {
     description: model.info.description,

--- a/src/test/java/KoopFeatureLayerTests.java
+++ b/src/test/java/KoopFeatureLayerTests.java
@@ -1,0 +1,48 @@
+import io.restassured.RestAssured;
+import org.junit.*;
+
+import static org.hamcrest.Matchers.is;
+
+public class KoopFeatureLayerTests extends AbstractFeatureServiceTest {
+    private static String endpoint = "/LATEST/resources/KoopFeatureLayer";
+
+    @Test
+    public void testServiceExists() {
+        RestAssured
+            .given()
+                .param("rs:service", "GeoLocation")
+            .when()
+                .log().uri()
+                .get(endpoint)
+            .then()
+                .log().ifError()
+                .statusCode(200)
+                .body("layers.size()", is(11))
+            ;
+    }
+
+    @Test
+    public void testServiceDoesntExist() {
+        RestAssured
+            .given()
+                .param("rs:service", "__SERVICE_MODEL_THAT_SHOULDNT_EXIST__")
+            .when()
+                .log().uri()
+                .get(endpoint)
+            .then()
+                .statusCode(404)
+            ;
+    }
+
+    @Test
+    public void testNoServiceParameter() {
+        RestAssured
+            .given()
+            .when()
+                .log().uri()
+                .get(endpoint)
+            .then()
+                .statusCode(400)
+            ;
+    }    
+}


### PR DESCRIPTION
For potential hotfix to address #29.

- Added "exact" query option in `getServiceModel()`
- Moved `getServiceModel()` into a "common" module since it was being used by both `KoopFeatureLayer` and `geoQueryService`.  

Note that the test database already has stemming explicitly set to `basic`.

Since `getServiceModel()` is an internal function, I used `KoopFeatureLayer` to test it out (since it didn't have test cases yet).

- Added traces and appropriate response codes to `KoopFeatureLayer`
- Added test cases (aka `gradle test -PenvironmentName=test`)