### PR TITLE
Tests all run as the writer user now

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ task loadGDeltTestData(type: com.marklogic.gradle.task.MlcpTask) {
   input_file_path = "data/test/gkg_geojson"
   input_compressed = "true"
   output_collections = "example-gkg,test-data"
-  output_permissions = "rest-reader,read,rest-writer,update"
+  output_permissions = "geo-data-services-reader,read,geo-data-services-writer,update"
   output_uri_replace = ".*/data/test/,'/'"
   transform_module = "/transform-gkg.sjs"
   transform_function = "transformGKG"
@@ -76,7 +76,7 @@ task loadGeoLocationTestData(type: com.marklogic.gradle.task.MlcpTask) {
   input_file_path = "data/test/GeoLocation"
   input_compressed = "true"
   output_collections = "example-geo,test-data"
-  output_permissions = "rest-reader,read,rest-writer,update"
+  output_permissions = "geo-data-services-reader,read,geo-data-services-writer,update"
   output_uri_replace = ".*/data/test/,'/'"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,5 @@ mlSchemasDatabaseName=geo-data-services-test-schemas
 mlContentForestsPerHost=1
 serviceDescriptorPermissions=geo-data-services-reader,read,geo-data-services-writer,update
 
-testUsername=admin
-testPassword=admin
+testUsername=test-geo-data-services-writer
+testPassword=test-geo-data-services-writer

--- a/src/test/java/AbstractTest.java
+++ b/src/test/java/AbstractTest.java
@@ -19,8 +19,8 @@ public abstract class AbstractTest {
         RestAssured.baseURI = "http://" + this.host;
         RestAssured.port = this.port;
 
-        this.username = System.getProperty("feature.username", "admin");
-        this.password = System.getProperty("feature.password", "admin");
+        this.username = System.getProperty("feature.username", "test-geo-data-services-writer");
+        this.password = System.getProperty("feature.password", "test-geo-data-services-writer");
         
         RestAssured.authentication = basic(this.username, this.password);
     }


### PR DESCRIPTION
The fix was that the data loaded by MLCP wasn't visible by the writer user. 

I think it'd be nice for some of these tests to eventually run as a "reader" user, but for now, this is a good improvement over having the tests all run as an "admin" user. 