### PR TITLE
Renamed baseName of artifact to marklogic-geo-data-services

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,16 +113,16 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task modulesJar(type: Jar) {
     description = "Jar up the marklogic-unit-test MarkLogic modules into a package that can be published"
     from("src/main/ml-config") {
-        into("marklogic-geo-data-services-modules/ml-config")
+        into("marklogic-geo-data-services/ml-config")
     }
     from("src/main/ml-modules") {
-        into("marklogic-geo-data-services-modules/ml-modules")
+        into("marklogic-geo-data-services/ml-modules")
     }
     from("src/main/ml-plugins") {
-        into("marklogic-geo-data-services-modules/ml-plugins")
+        into("marklogic-geo-data-services/ml-plugins")
     }
     destinationDir file("build/libs")
-    baseName "marklogic-geo-data-services-modules"
+    baseName "marklogic-geo-data-services"
 }
 
 artifacts {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,6 @@ mlSchemaPaths=src/test/ml-schemas
 mlContentDatabaseName=geo-data-services-test-content
 mlSchemasDatabaseName=geo-data-services-test-schemas
 mlContentForestsPerHost=1
-serviceDescriptorPermissions=geo-data-services-reader,read,geo-data-services-writer,update
 
 testUsername=test-geo-data-services-writer
 testPassword=test-geo-data-services-writer


### PR DESCRIPTION
This isn't a breaking change for users, as the folder name in the mlBundle zip is only exposed in Gradle's build directory, which I think we can consider to be private. 

Also removed the unused "serviceDescriptorPermissions" property. 