### PR TITLE
Removed obsolete "type" from "geometry"

### DIFF
--- a/examples/arcgis-hub-example/src/main/ml-data/arcgis-hub-service.json
+++ b/examples/arcgis-hub-example/src/main/ml-data/arcgis-hub-service.json
@@ -12,7 +12,6 @@
       "schema": "arcgis_hub",
       "view": "mollusks",
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"

--- a/examples/sample-project/src/main/ml-data/example/services/GDeltExample.json
+++ b/examples/sample-project/src/main/ml-data/example/services/GDeltExample.json
@@ -30,7 +30,6 @@
       "schema": "GDeltGKG",
       "view" : "Article",
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"
@@ -66,7 +65,6 @@
         }
       },
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"
@@ -98,7 +96,6 @@
         }
       },
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"
@@ -130,7 +127,6 @@
         }
       },
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"
@@ -162,7 +158,6 @@
         }
       },
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"

--- a/src/main/ml-modules/root/marklogic-geo-data-services/serviceLib.sjs
+++ b/src/main/ml-modules/root/marklogic-geo-data-services/serviceLib.sjs
@@ -202,7 +202,6 @@ function calculateNewLayerModelIndex(serviceModel, layerId) {
         // default the geometry to GeoJSON
         if (!layer.geometry) {
             layer.geometry = {
-                type: "Point",
                 format: "geojson",
                 coordinateSystem: "wgs84",
                 xpath: "//geometry"

--- a/src/test/java/GeoJSONGeometry.java
+++ b/src/test/java/GeoJSONGeometry.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.is;
 public class GeoJSONGeometry  extends AbstractFeatureServiceTest {
 
     // "geometry" : {
-    //   "type" : "Polygon",
     //   "format" : "geojson",
     //   "coordinateSystem" : "wgs84",
     //   "source" : {
@@ -35,7 +34,6 @@ public class GeoJSONGeometry  extends AbstractFeatureServiceTest {
     }
 
     // "geometry" : {
-    //   "type" : "Polygon",
     //   "format" : "geojson",
     //   "coordinateSystem" : "wgs84",
     //   "source" : {
@@ -59,7 +57,6 @@ public class GeoJSONGeometry  extends AbstractFeatureServiceTest {
     }
 
     // "geometry" : {
-    //   "type" : "Polygon",
     //   "format" : "geojson",
     //   "coordinateSystem" : "wgs84",
     //   "source" : {

--- a/src/test/java/WKTGeometry.java
+++ b/src/test/java/WKTGeometry.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.is;
 public class WKTGeometry  extends AbstractFeatureServiceTest {
 
     // "geometry" : {
-    //   "type" : "Polygon",
     //   "format" : "wkt",
     //   "coordinateSystem" : "wgs84",
     //   "source" : {
@@ -36,7 +35,6 @@ public class WKTGeometry  extends AbstractFeatureServiceTest {
     }
 
     // "geometry" : {
-    //   "type" : "Polygon",
     //   "format" : "wkt",
     //   "coordinateSystem" : "wgs84",
     //   "source" : {

--- a/src/test/ml-data/feature-services/test/GDeltGKG.json
+++ b/src/test/ml-data/feature-services/test/GDeltGKG.json
@@ -33,7 +33,6 @@
         }
       },
       "geometry": {
-        "type": "Point",
         "format": "geojson",
         "coordinateSystem": "wgs84",
         "xpath": "//geometry"
@@ -258,7 +257,6 @@
         }
       },
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"
@@ -301,7 +299,6 @@
         }
       },
       "geometry": {
-        "type": "Point",
         "format": "geojson",
         "coordinateSystem": "wgs84",
         "xpath": "//geometry"

--- a/src/test/ml-data/feature-services/test/GDeltSearch.json
+++ b/src/test/ml-data/feature-services/test/GDeltSearch.json
@@ -30,7 +30,6 @@
       "schema": "GDeltGKG",
       "view" : "Article",
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"
@@ -59,7 +58,6 @@
       "schema": "GDeltGKG",
       "view" : "Article",
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"
@@ -85,7 +83,6 @@
       "schema": "GDeltGKG",
       "view" : "Article",
       "geometry" : {
-        "type" : "Point",
         "format" : "geojson",
         "coordinateSystem" : "wgs84",
         "xpath" : "//geometry"

--- a/src/test/ml-data/feature-services/test/GeoLocation.json
+++ b/src/test/ml-data/feature-services/test/GeoLocation.json
@@ -24,7 +24,6 @@
       "schema": "GeoLocation",
       "view": "GeoGML",
       "geometry": {
-        "type": "Point",
         "format": "gml",
         "pointFormat": "point",
         "coordinateSystem": "wgs84"
@@ -50,7 +49,6 @@
       "schema": "GeoLocation",
       "view": "GeoKML",
       "geometry": {
-        "type": "Point",
         "format": "kml",
         "coordinateSystem": "wgs84"
       },
@@ -75,7 +73,6 @@
       "schema": "GeoLocation",
       "view": "GeoRSS",
       "geometry": {
-        "type": "Point",
         "format": "rss",
         "coordinateSystem": "wgs84"
       },
@@ -100,7 +97,6 @@
       "schema": "GeoLocation",
       "view": "GeoMCGM",
       "geometry": {
-        "type": "Point",
         "format": "mcgm",
         "coordinateSystem": "wgs84"
       },
@@ -202,7 +198,6 @@
       "schema": "GeoLocation",
       "view": "GeoAny",
       "geometry": {
-        "type": "Point",
         "format": "any",
         "coordinateSystem": "wgs84"
       },
@@ -227,7 +222,6 @@
       "schema": "GeoLocation",
       "view": "GeoWKT",
       "geometry": {
-        "type": "Polygon",
         "format": "wkt",
         "coordinateSystem": "wgs84",
         "source": {
@@ -254,7 +248,6 @@
       "schema": "GeoLocation",
       "view": "GeoWKT",
       "geometry": {
-        "type": "Polygon",
         "format": "wkt",
         "coordinateSystem": "wgs84",
         "source": {
@@ -281,7 +274,6 @@
       "schema": "GeoLocation",
       "view": "GeoJSON",
       "geometry": {
-        "type": "Polygon",
         "format": "geojson",
         "coordinateSystem": "wgs84",
         "source": {
@@ -308,7 +300,6 @@
       "schema": "GeoLocation",
       "view": "GeoJSON",
       "geometry": {
-        "type": "Polygon",
         "format": "geojson",
         "coordinateSystem": "wgs84",
         "source": {
@@ -335,7 +326,6 @@
       "schema": "GeoLocation",
       "view": "GeoJSON",
       "geometry": {
-        "type": "Polygon",
         "format": "geojson",
         "coordinateSystem": "wgs84",
         "source": {


### PR DESCRIPTION
I found no references to this, and all tests pass with `type` removed. `geometry` is a GDS-specific construct as well. ArcGIS cares about `geometryType`.